### PR TITLE
Support dataclass-based component helpers

### DIFF
--- a/pyomo_models/build/functions.py
+++ b/pyomo_models/build/functions.py
@@ -1,247 +1,178 @@
-from pyomo.environ import *
+"""Utility helpers for building Pyomo models.
+
+These helpers allow model components to be defined using dataclasses and
+``Enum`` members rather than raw strings.  Each dataclass is expected to provide
+at least a ``name`` attribute which is used when creating or replacing the
+component on a model instance.
+"""
+
+from __future__ import annotations
+
 from functools import reduce
 from operator import mul
-from typing import List, Dict, Tuple, Union
+from typing import Any, Iterable
 import inspect
 import logging
-
-from .definitions import ComponentName, SetDef, VarDef, ConstraintDef, ParamDef
 from enum import Enum
+
+from pyomo.environ import *  # noqa: F401,F403 - re-export Pyomo classes
 
 # Set up logger
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)  # Change to DEBUG for more details
+logger.setLevel(logging.INFO)
 handler = logging.StreamHandler()
-formatter = logging.Formatter('%(asctime)s [%(levelname)s] %(message)s')
+formatter = logging.Formatter("%(asctime)s [%(levelname)s] %(message)s")
 handler.setFormatter(formatter)
 logger.addHandler(handler)
 
 
-def _initialize_resolver(defined_initialize):
-    #Take function or value defined in set_initialize and check if callable.
-    #If callable then call using brackets if no parameters, or without if >0 parameters defined
-    #If not collable then return as is.
+def _initialize_resolver(defined_initialize: Any) -> Any:
+    """Return a value or callable suitable for Pyomo initialisation."""
+
     if callable(defined_initialize):
         sig = inspect.signature(defined_initialize)
-        if len(sig.parameters) == 0:
-            return defined_initialize()
-        else:
-            return defined_initialize
+        return defined_initialize() if len(sig.parameters) == 0 else defined_initialize
     return defined_initialize
 
-def _index_resolver(instance, defined_index):
-    """Resolve index definitions into pyomo objects."""
+
+def _resolve_component(instance: Any, source: Any) -> Any:
+    """Return a component from ``instance`` based on ``source``.
+
+    ``source`` may be an :class:`Enum` member, an object with a ``name``
+    attribute (e.g., a dataclass describing a component) or a raw string.  Any
+    other object is returned unchanged.
+    """
+
+    if isinstance(source, Enum):
+        return getattr(instance, source.value)
+    if hasattr(source, "name"):
+        name = getattr(source, "name")
+        if isinstance(name, Enum):
+            name = name.value
+        return getattr(instance, name)
+    if isinstance(source, str):
+        return getattr(instance, source)
+    return source
+
+
+def _index_resolver(instance: Any, defined_index: Any) -> Any:
+    """Resolve index definitions into Pyomo objects."""
+
     if defined_index is None:
         return None
-    if isinstance(defined_index, ComponentName):
-        return getattr(instance, defined_index.value)
-    if isinstance(defined_index, str):
-        return getattr(instance, defined_index)
     if isinstance(defined_index, tuple):
-        resolved = []
-        for index_set in defined_index:
-            if isinstance(index_set, ComponentName):
-                resolved.append(getattr(instance, index_set.value))
-            elif isinstance(index_set, str):
-                resolved.append(getattr(instance, index_set))
-            else:
-                resolved.append(index_set)
+        resolved = [_resolve_component(instance, idx) for idx in defined_index]
         return reduce(mul, resolved)
-    return defined_index
+    return _resolve_component(instance, defined_index)
 
-def _within_resolver(instance, defined_within):
-    """Resolve within definitions into pyomo sets."""
+
+def _within_resolver(instance: Any, defined_within: Any) -> Any:
+    """Resolve within definitions into Pyomo sets."""
+
     if defined_within is None:
         return None
-    if isinstance(defined_within, ComponentName):
-        return getattr(instance, defined_within.value)
-    if isinstance(defined_within, str):
-        return getattr(instance, defined_within)
     if isinstance(defined_within, tuple):
-        resolved = []
-        for index_set in defined_within:
-            if isinstance(index_set, ComponentName):
-                resolved.append(getattr(instance, index_set.value))
-            elif isinstance(index_set, str):
-                resolved.append(getattr(instance, index_set))
-            else:
-                resolved.append(index_set)
+        resolved = [_resolve_component(instance, idx) for idx in defined_within]
         return reduce(mul, resolved)
-    return defined_within
+    return _resolve_component(instance, defined_within)
 
-def add_sets_to_instance(
-    instance: object, sets_dict_obj: object, set_list: list | None = None
-):
-    """Add sets defined by :class:`SetDef` objects to a model instance."""
-    if set_list is None:
-        set_list = list(sets_dict_obj.blocks.keys())
 
-    resolved_names = [
-        ComponentName(name) if isinstance(name, str) else name for name in set_list
-    ]
+def _name_to_str(name_obj: Any) -> str:
+    """Convert a dataclass or Enum ``name`` attribute to a string."""
 
-    for set_name in resolved_names:
-        set_def: SetDef = sets_dict_obj.blocks.get(set_name)
-        dimen = set_def.dimen
-        index = _index_resolver(instance, set_def.index)
-        within = _within_resolver(instance, set_def.within)
-        initialize = _initialize_resolver(set_def.initialize)
+    return name_obj.value if isinstance(name_obj, Enum) else str(name_obj)
+
+
+def add_sets_to_instance(instance: Any, set_defs: Iterable[Any]) -> None:
+    """Add sets defined by dataclass objects to a model instance."""
+
+    for set_def in set_defs:
+        dimen = getattr(set_def, "dimen", 1)
+        index = _index_resolver(instance, getattr(set_def, "index", None))
+        within = _within_resolver(instance, getattr(set_def, "within", None))
+        initialize = _initialize_resolver(getattr(set_def, "initialize", None))
 
         if index is not None:
-            component = Set(
-                index,
-                within=within,
-                initialize=initialize,
-                dimen=dimen,
-            )
+            component = Set(index, within=within, initialize=initialize, dimen=dimen)
         else:
-            component = Set(
-                within=within,
-                initialize=initialize,
-                dimen=dimen,
-            )
+            component = Set(within=within, initialize=initialize, dimen=dimen)
 
-        name_str = set_name.value
+        name_str = _name_to_str(getattr(set_def, "name"))
         if hasattr(instance, name_str):
             instance.del_component(getattr(instance, name_str))
             logger.info(f"Deleted and redefined set component {name_str}")
         instance.add_component(name_str, component)
 
-def add_params_to_instance(
-    instance: object, param_dict_obj: object, param_list: list | None = None
-):
-    all_defined_params = list(param_dict_obj.blocks.keys())
 
-    if param_list is None:
-        param_list = all_defined_params
+def add_params_to_instance(instance: Any, param_defs: Iterable[Any]) -> None:
+    """Add parameters defined by dataclass objects to a model instance."""
 
-    resolved_names = [
-        ComponentName(name) if isinstance(name, str) else name for name in param_list
-    ]
-
-    for param_name in resolved_names:
-        if param_name not in all_defined_params:
-            raise KeyError(
-                f"Constraint '{param_name}' not found in block '{all_defined_params}'"
-            )
-
-        param_def: ParamDef = param_dict_obj.blocks.get(param_name)
-        index = _index_resolver(instance, param_def.index)
-        within = _within_resolver(instance, param_def.within)
-        initialize = _initialize_resolver(param_def.initialize)
-        mutable = param_def.mutable
+    for param_def in param_defs:
+        index = _index_resolver(instance, getattr(param_def, "index", None))
+        within = _within_resolver(instance, getattr(param_def, "within", None))
+        initialize = _initialize_resolver(getattr(param_def, "initialize", None))
+        mutable = getattr(param_def, "mutable", False)
 
         if index is not None:
-            component = Param(
-                index,
-                within=within,
-                initialize=initialize,
-                mutable=mutable,
-            )
+            component = Param(index, within=within, initialize=initialize, mutable=mutable)
         else:
-            component = Param(
-                within=within,
-                initialize=initialize,
-                mutable=mutable,
-            )
+            component = Param(within=within, initialize=initialize, mutable=mutable)
 
-        name_str = param_name.value
+        name_str = _name_to_str(getattr(param_def, "name"))
         if hasattr(instance, name_str):
             instance.del_component(getattr(instance, name_str))
-            logger.info(
-                f"Deleted and redefined parameter component {name_str}"
-            )
+            logger.info(f"Deleted and redefined parameter component {name_str}")
         instance.add_component(name_str, component)
-    
-def add_variables_to_instance(
-    instance: object, variable_dict_obj: object, variable_list: list | None = None
-):
-    all_defined_variables = list(variable_dict_obj.blocks.keys())
 
-    if variable_list is None:
-        variable_list = all_defined_variables
 
-    resolved_names = [
-        ComponentName(name) if isinstance(name, str) else name for name in variable_list
-    ]
+def add_variables_to_instance(instance: Any, variable_defs: Iterable[Any]) -> None:
+    """Add variables defined by dataclass objects to a model instance."""
 
-    for variable_name in resolved_names:
-        if variable_name not in all_defined_variables:
-            raise KeyError(
-                f"Constraint '{variable_name}' not found in block '{all_defined_variables}'"
-            )
-
-        variable_def: VarDef = variable_dict_obj.blocks.get(variable_name)
-        index = _index_resolver(instance, variable_def.index)
-        domain = variable_def.domain
-        bounds = variable_def.bounds
-        initialize = _initialize_resolver(variable_def.initialize)
+    for variable_def in variable_defs:
+        index = _index_resolver(instance, getattr(variable_def, "index", None))
+        domain = getattr(variable_def, "domain", None)
+        bounds = getattr(variable_def, "bounds", None)
+        initialize = _initialize_resolver(getattr(variable_def, "initialize", None))
 
         if index is not None:
-            component = Var(
-                index,
-                domain=domain,
-                bounds=bounds,
-                initialize=initialize,
-            )
+            component = Var(index, domain=domain, bounds=bounds, initialize=initialize)
         else:
-            component = Var(
-                domain=domain,
-                bounds=bounds,
-                initialize=initialize,
-            )
+            component = Var(domain=domain, bounds=bounds, initialize=initialize)
 
-        name_str = variable_name.value
+        name_str = _name_to_str(getattr(variable_def, "name"))
         if hasattr(instance, name_str):
             instance.del_component(getattr(instance, name_str))
-            logger.info(
-                f"Deleted and redefined variable component {name_str}"
-            )
+            logger.info(f"Deleted and redefined variable component {name_str}")
         instance.add_component(name_str, component)
-    
-def add_constraints_to_instance(
-    instance: object, constraint_dict_obj: object, constraint_list: list | None = None
-):
-    all_defined_constraints = list(constraint_dict_obj.blocks.keys())
 
-    if constraint_list is None:
-        constraint_list = all_defined_constraints
 
-    resolved_names = [
-        ComponentName(name) if isinstance(name, str) else name for name in constraint_list
-    ]
+def add_constraints_to_instance(instance: Any, constraint_defs: Iterable[Any]) -> None:
+    """Add constraints defined by dataclass objects to a model instance."""
 
-    for constraint_name in resolved_names:
-        if constraint_name not in all_defined_constraints:
-            raise KeyError(
-                f"Constraint '{constraint_name}' not found in block '{all_defined_constraints}'"
-            )
-
-        constraint_def: ConstraintDef = constraint_dict_obj.blocks.get(constraint_name)
-        index = _index_resolver(instance, constraint_def.index)
-        rule = constraint_def.rule
+    for constraint_def in constraint_defs:
+        index = _index_resolver(instance, getattr(constraint_def, "index", None))
+        rule = getattr(constraint_def, "rule")
 
         if index is not None:
-            component = Constraint(
-                index,
-                rule=rule,
-            )
+            component = Constraint(index, rule=rule)
         else:
-            component = Constraint(
-                rule=rule,
-            )
+            component = Constraint(rule=rule)
 
-        name_str = constraint_name.value
+        name_str = _name_to_str(getattr(constraint_def, "name"))
         if hasattr(instance, name_str):
             instance.del_component(getattr(instance, name_str))
-            logger.info(
-                f"Deleted and redefined constraint component {name_str}"
-            )
+            logger.info(f"Deleted and redefined constraint component {name_str}")
         instance.add_component(name_str, component)
 
-def remove_component_from_instance(instance: object, component_list: list):
-    for set_name in component_list:
-        if hasattr(instance, set_name):
-            instance.del_component(getattr(instance,set_name))
+
+def remove_component_from_instance(instance: Any, component_list: Iterable[str]) -> None:
+    """Remove components from a model instance."""
+
+    for name in component_list:
+        if hasattr(instance, name):
+            instance.del_component(getattr(instance, name))
         else:
-            raise KeyError(f"Set '{set_name}' cannot be deleted as it does not exist in the instance")
+            raise KeyError(
+                f"Set '{name}' cannot be deleted as it does not exist in the instance"
+            )
+

--- a/tests/test_build_functions.py
+++ b/tests/test_build_functions.py
@@ -1,0 +1,93 @@
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Callable
+
+import pytest
+
+pytest.importorskip("pyomo")
+from pyomo.environ import ConcreteModel, NonNegativeReals
+
+from pyomo_models.build.functions import (
+    add_constraints_to_instance,
+    add_params_to_instance,
+    add_sets_to_instance,
+    add_variables_to_instance,
+)
+
+
+class Names(Enum):
+    A = "A"
+    B = "B"
+    P = "P"
+    X = "X"
+    C = "C"
+
+
+@dataclass
+class SetDefDC:
+    name: Names
+    index: Any = None
+    within: Any = None
+    initialize: Any = None
+    dimen: int = 1
+
+
+@dataclass
+class ParamDefDC:
+    name: Names
+    index: Any = None
+    within: Any = None
+    initialize: Any = None
+    mutable: bool = False
+
+
+@dataclass
+class VarDefDC:
+    name: Names
+    index: Any = None
+    domain: Any = None
+    bounds: tuple | None = None
+    initialize: Any = None
+
+
+@dataclass
+class ConstraintDefDC:
+    name: Names
+    index: Any = None
+    rule: Callable | None = None
+
+
+def test_build_helpers_accept_dataclasses_and_enums():
+    model = ConcreteModel()
+
+    set_a = SetDefDC(name=Names.A, initialize=[1, 2])
+    set_b = SetDefDC(name=Names.B, within=set_a, initialize=[1])
+    add_sets_to_instance(model, [set_a, set_b])
+
+    assert sorted(model.A.data()) == [1, 2]
+    assert sorted(model.B.data()) == [1]
+    assert model.B.domain is model.A
+
+    param_p = ParamDefDC(name=Names.P, index=set_a, initialize={1: 10, 2: 20})
+    add_params_to_instance(model, [param_p])
+    assert model.P[1] == 10
+    assert model.P.index_set() is model.A
+
+    var_x = VarDefDC(
+        name=Names.X,
+        index=set_a,
+        domain=NonNegativeReals,
+        initialize=5,
+    )
+    add_variables_to_instance(model, [var_x])
+    assert model.X[1].value == 5
+    assert model.X.index_set() is model.A
+
+    def rule(m, i):
+        return m.X[i] >= m.P[i]
+
+    constraint_c = ConstraintDefDC(name=Names.C, index=Names.A, rule=rule)
+    add_constraints_to_instance(model, [constraint_c])
+    assert len(model.C) == 2
+    assert model.C.index_set() is model.A
+


### PR DESCRIPTION
## Summary
- Allow `_index_resolver` and `_within_resolver` to resolve Enum members or dataclass definitions
- Replace helper utilities to work with iterables of dataclass instances and use their `name` attributes
- Add type hints and unit test showing dataclass/Enum based component creation

## Testing
- `pip install pyomo` *(failed: Could not connect to proxy)*
- `pytest -q` *(skipped: pyomo not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68a30bc08da883259f6e39fced5f5259